### PR TITLE
fix: update Gemini model from gemini-pro to gemini-2.0-flash

### DIFF
--- a/lambda/geminiHandler.mjs
+++ b/lambda/geminiHandler.mjs
@@ -2,7 +2,7 @@ import https from 'https';
 
 // Gemini API configuration
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
-const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent';
+const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
 
 // CORS configuration
 const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS

--- a/src/services/ai/geminiService.ts
+++ b/src/services/ai/geminiService.ts
@@ -33,7 +33,7 @@ interface GeminiResponse {
  */
 export class GeminiService {
   private apiKey: string;
-  private apiUrl: string = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent';
+  private apiUrl: string = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
 
   constructor(apiKey: string) {
     this.apiKey = apiKey;


### PR DESCRIPTION
This commit updates the Gemini API model name from 'gemini-pro' to 'gemini-2.0-flash'
in both the Lambda function and frontend service.

Changes:
- Update model name in geminiHandler.mjs for the Lambda function
- Update model name in geminiService.ts for the frontend service

This change ensures the application uses the correct and most appropriate
Gemini model for chess analysis and move generation.